### PR TITLE
Cohort analysis on more that one page

### DIFF
--- a/lib/cohorts.js
+++ b/lib/cohorts.js
@@ -14,8 +14,8 @@ Cohorts = (function() {
                 throw(" _gaq object not found: It looks like you haven't correctly setup the asynchronous Google Analytics tracking code, and you are using the default GoogleAnalyticsAdapter.");
             }
         },
-        onInitialize: function(inTest, testName, cohort) {
-            if(inTest) {
+        onInitialize: function(inTest, testName, cohort, new_to_this_test) {
+            if(inTest && new_to_this_test) {
                 this.trackEvent(this.nameSpace, testName, cohort + ' | Total');
             }
         },
@@ -71,8 +71,13 @@ Cohorts = (function() {
                 
                 // Determine whether user should be in the test
                 var in_test = this.inTest();
-                if(in_test === null) // haven't seen this user before
+                var new_to_this_test = null;
+                if(in_test === null) { // haven't seen this user before
                     in_test = Math.random() <= this.options.sample;
+                    if (in_test) new_to_this_test = true;
+                }
+                else
+                	new_to_this_test = false;
                     
                 if(in_test) {
                     this.setCookie('in_test', 1);
@@ -86,7 +91,7 @@ Cohorts = (function() {
                     } else {
                         var chosen_cohort = this.getCohort();
                     }
-                    this.options.storageAdapter.onInitialize(in_test, this.options.name, chosen_cohort);
+                    this.options.storageAdapter.onInitialize(in_test, this.options.name, chosen_cohort, new_to_this_test);
                     
                     // call the onChosen handler, if it exists
                     if(this.options.cohorts[chosen_cohort].onChosen)

--- a/test/dev_storageAdapter.html
+++ b/test/dev_storageAdapter.html
@@ -44,24 +44,29 @@
                         },
                         small: {},
                     },
+					// This storage adapter just push events in browser console
+					// and gives you a warning if Google Analytics is not included
+					// It is designed for development environments
                     storageAdapter: {
-                        nameSpace: 'storageAdapter_cohorts',
-                        trackEvent: function(category, action, opt_label, opt_value) {
-                            if(window['_gaq']) {
-                                _gaq.push(['_trackEvent', category, action, opt_label, opt_value]);
-                            } else {
-                                throw(" _gaq object not found: It looks like you haven't correctly setup the asynchronous Google Analytics tracking code, and you are using the default GoogleAnalyticsAdapter.");
-                            }
-                        },
-                        onInitialize: function(inTest, testName, cohort, new_to_this_test) {
-                            if(inTest && new_to_this_test) {
-                                this.trackEvent(this.nameSpace, testName, cohort + ' | Total');
-                            }
-                        },
-                        onEvent: function(testName, cohort, eventName) {
-                            this.trackEvent(this.nameSpace, testName, cohort + ' | ' + eventName);
-                        }
-                    }
+						nameSpace: 'cohorts',
+						trackEvent: function(category, action, opt_label, opt_value) {
+							console.log('trackEvent: ' + category + ', ' + action + ', ' + opt_label + ', ' + opt_value);
+
+							if(window['_gaq']) {
+								// this does nothing because this is a test adapter
+							} else {
+								console.log("_gaq object not found: It looks like you haven't correctly setup the asynchronous Google Analytics tracking code, and you are using the default GoogleAnalyticsAdapter.");
+							}
+						},
+						onInitialize: function(inTest, testName, cohort, new_to_this_test) {
+							if(inTest && new_to_this_test) {
+								this.trackEvent(this.nameSpace, testName, cohort + ' | Total');
+							}
+						},
+						onEvent: function(testName, cohort, eventName) {
+							this.trackEvent(this.nameSpace, testName, cohort + ' | ' + eventName);
+						}
+					}
                 });
             
                 $('#big').click(function() {


### PR DESCRIPTION
Cohort framework could do tests only in one page because
the onInitialize event was called every time, even if a user was in a
certain Cohort in the previous page.
Now onInitialize has the parameter "new_to_this_test" so that you can
call the event "cohort + ' | Total'" only when the user enters to the
test, and not all the times the test is initialized.
